### PR TITLE
Added newline to end of generated changelog

### DIFF
--- a/change/log.py
+++ b/change/log.py
@@ -322,6 +322,7 @@ def compile_changelog(fragment_dir, output, item_format, categories: List[str]):
                     categories,
                 ):
                     out_stream.write(line + "\n")
+        out_stream.write("\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Generated changelogs did not include a newline at the end of file. This might make several tools complain ;)